### PR TITLE
fix encoding on macos

### DIFF
--- a/parophone.py
+++ b/parophone.py
@@ -1,5 +1,8 @@
+#!/usr/bin/python3
+# -*- coding: iso-8859-1 -*-
+
 import csv
-f = open("assets/distance_sons.csv")
+f = open("assets/distance_sons.csv", encoding="iso-8859-1")
 distance_sons = f.readlines()
 
 


### PR DESCRIPTION
On MacOS, encoding is defaulted to utf-8, which means the code can't load the file, and the characters in the code are also not recognized.

Passing `encoding` to `open` only works in python3.